### PR TITLE
カレンダーページの作成

### DIFF
--- a/EmployeeManagementWebApp/src/main/java/com/example/controller/PunchController.java
+++ b/EmployeeManagementWebApp/src/main/java/com/example/controller/PunchController.java
@@ -2,9 +2,12 @@ package com.example.controller;
 
 import java.security.Principal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
 import com.example.model.Stamp;
@@ -60,5 +63,16 @@ public class PunchController {
         }
 
         return "redirect:/hello";
+    }
+    
+    @GetMapping("/calendar")
+    public String showCalendar(Principal principal, Model model) {
+        // 現在ログインしているユーザーのstampリストを取得
+        List<Stamp> stampList = stampService.getStampByEmployeeId(principal.getName());
+
+        // モデルにリストを追加
+        model.addAttribute("stampList", stampList);
+
+        return "/calendar";
     }
 }

--- a/EmployeeManagementWebApp/src/main/java/com/example/repository/StampRepository.java
+++ b/EmployeeManagementWebApp/src/main/java/com/example/repository/StampRepository.java
@@ -1,5 +1,7 @@
 package com.example.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.model.Stamp;
@@ -7,4 +9,6 @@ import com.example.model.Stamp;
 public interface StampRepository extends JpaRepository<Stamp, Long> {
 	// employee_idが現在ログインしているユーザーの名前であり、かつend_timeがnullであるレコードを取得
     Stamp findByEmployeeIdAndEndTimeIsNullOrderByStartTimeDesc(String employeeId);
+
+	List<Stamp> findByEmployeeId(String employeeId);
 }

--- a/EmployeeManagementWebApp/src/main/java/com/example/securingweb/MvcConfig.java
+++ b/EmployeeManagementWebApp/src/main/java/com/example/securingweb/MvcConfig.java
@@ -12,5 +12,6 @@ public class MvcConfig implements WebMvcConfigurer {
         registry.addViewController("/").setViewName("home");
         registry.addViewController("/hello").setViewName("hello");
         registry.addViewController("/login").setViewName("login");
+        registry.addViewController("/calendar").setViewName("calendar");
     }
 }

--- a/EmployeeManagementWebApp/src/main/java/com/example/service/StampService.java
+++ b/EmployeeManagementWebApp/src/main/java/com/example/service/StampService.java
@@ -33,4 +33,8 @@ public class StampService {
     public Stamp getLastStamp(String employeeId) {
         return stampRepository.findByEmployeeIdAndEndTimeIsNullOrderByStartTimeDesc(employeeId);
     }
+
+	public List<Stamp> getStampByEmployeeId(String employeeId) {
+		return stampRepository.findByEmployeeId(employeeId);
+	}
 }

--- a/EmployeeManagementWebApp/src/main/resources/templates/calendar.html
+++ b/EmployeeManagementWebApp/src/main/resources/templates/calendar.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
+<head>
+    <title>カレンダーページ</title>
+    <style>
+        table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+        th, td {
+            border: 1px solid #dddddd;
+            text-align: left;
+            padding: 8px;
+        }
+    </style>
+</head>
+<body>
+    <h1>カレンダー</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>日付</th>
+                <th>出勤時間</th>
+                <th>退勤時間</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Loop through the stamp list and display information -->
+            <tr th:each="stamp : ${stampList}">
+                <td th:text="${stamp.startTime.toLocalDate()}"></td>
+                <td th:text="${stamp.startTime.toLocalTime()}"></td>
+                <td th:if="${stamp.endTime != null}" th:text="${stamp.endTime.toLocalTime()}"></td>
+                <td th:if="${stamp.endTime == null}">未退勤</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/EmployeeManagementWebApp/src/main/resources/templates/hello.html
+++ b/EmployeeManagementWebApp/src/main/resources/templates/hello.html
@@ -32,7 +32,13 @@
     <form action="/logout" method="post">
         <!-- CSRFトークンの追加 -->
         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
-        <input type="submit" value="ログアウト"/>
+        <input type="submit" value="Sign Out"/>
+    </form>
+    
+    <form action="/calendar" method="get">
+        <!-- CSRFトークンの追加 -->
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+        <input type="submit" value="勤怠"/>
     </form>
 </body>
 </html>

--- a/EmployeeManagementWebApp/src/main/resources/templates/home.html
+++ b/EmployeeManagementWebApp/src/main/resources/templates/home.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org">
-    <head>
-        <title>Spring Security Example</title>
-    </head>
-    <body>
-        <h1>Welcome!</h1>
+<head>
+    <title>Spring Security Example</title>
+</head>
+<body>
+    <h1>Welcome!</h1>
 
-        <p>Click <a th:href="@{/hello}">here</a> to see a greeting.</p>
-    </body>
+    <p>Click <a th:href="@{/hello}">here</a> to see a greeting.</p>
+</body>
 </html>


### PR DESCRIPTION
# 実装したこと

- カレンダーページの作成
   - 日付、出勤時間、退勤時間を表示する空のHTMLを作成
   - 打刻ページに「勤怠」ボタンの追加
   - コントローラーに「勤怠」ボタンが押されたときカレンダーページへ遷移するように記述

# 実装結果
![image](https://github.com/mao0905/EmployeeManagementWebAppApplication/assets/25600726/a58b4de3-79a3-478b-a59b-6df6b59ada4c)

![image](https://github.com/mao0905/EmployeeManagementWebAppApplication/assets/25600726/7f9c76a6-7118-4777-84ea-8cf8ea081838)
